### PR TITLE
Feature/remove object db from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Leiningen coordinates:
 The library provides `wrap-background-job` function, which can be used to start the message queue. 
 This function requires your configuration in the form:
 ```clojure 
- {:object-db-conn datomic-db-connection
-  :tiny-queue-db-conn datomic-db-connection
+ {:tiny-queue-db-conn datomic-db-connection
   :q d/q
   :db d/db
   :transact d/transact-async
@@ -31,8 +30,7 @@ To start message queue You should do following steps:
 (require '[datomic.api :as d])
 (def conn (d/connect "your-datomic-db-uri"))
 (def config 
-  {:object-db-conn conn
-   :tiny-queue-db-conn conn
+  {:tiny-queue-db-conn conn
    :q d/q
    :db d/db
    :transact d/transact-async
@@ -48,10 +46,9 @@ To start message queue You should do following steps:
 ```
 4. Define first job processor (processor should return Datomic transaction):
 ```clojure
-(defn first-job-processor [tiny-queue-db-snapshot object-db-snapshot job uuid]
+(defn first-job-processor [tiny-queue-db-snapshot job uuid]
   (println "Processing first job" uuid)
-  {:object-db-transaction []
-   :tiny-queue-db-transaction []})
+  [])
 ```
 5. Define proper `tiny-queue-processors`:
 ```clojure

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ This function requires your configuration in the form:
   :tiny-queue-processors {}}
 ```
 Where `d` is one of `datomic.api`, `datomic.client.api`. The most important part of the configuration is `tiny-queue-processors`.
-It should be a map with db idents as keys and functions as values.
+It should be a map with db idents as keys and functions as values. Each function should conform to a spec `tiny-queue-processor`.
+
+```clojure
+(s/fdef tiny-queue-processor
+  :args (s/cat :tiny-queue-db-snapshot any?
+               :job map?
+               :processor-uuid uuid?)
+  :ret (s/coll-of #(or (map? %) (vector? %))))
+```
 
 ## Examples
 

--- a/src/tiny_queue/core.clj
+++ b/src/tiny_queue/core.clj
@@ -37,9 +37,12 @@
         (cond-> blocked (assoc :qmessage/blocked blocked))
         (cond-> object (assoc :qmessage/object-uuid object)))))
 
+(defn get-new-job-transaction [job-params]
+  [(get-new-job job-params)])
+
 (defn create-new-job
   [config job-params]
-  ((:transact config) (:tiny-queue-db-conn config) [(get-new-job job-params)]))
+  ((:transact config) (:tiny-queue-db-conn config) (get-new-job-transaction job-params)))
 
 (defn define-new-job
   [config job-ident job-docs]

--- a/src/tiny_queue/core.clj
+++ b/src/tiny_queue/core.clj
@@ -78,7 +78,7 @@
                 :status :grab/fail}))
         false))))
 
-(defn try-transact
+(defn- try-transact
   ([config job processor-uuid transaction]
    (try-transact config job processor-uuid transaction 3))
   ([config job processor-uuid transaction retry-count]

--- a/src/tiny_queue/core.clj
+++ b/src/tiny_queue/core.clj
@@ -97,7 +97,8 @@
           (log {:job job
                 :processor-uuid processor-uuid
                 :exception e
-                :status :process/transaction-fail})
+                :status :process/transaction-fail
+                :retry-count retry-count})
           (try-transact
            config
            job

--- a/src/tiny_queue/db/schema.clj
+++ b/src/tiny_queue/db/schema.clj
@@ -1,7 +1,9 @@
 (ns tiny-queue.db.schema)
 
 (def qmessage-schema
-  [{:db/ident              :qmessage-status/failed
+  [{:db/ident              :qmessage-status/transaction-failed
+    :db/doc                "The qmessage status"}
+   {:db/ident              :qmessage-status/failed
     :db/doc                "The qmessage status"}
    {:db/ident              :qmessage-status/succeeded
     :db/doc                "The qmessage status"}

--- a/src/tiny_queue/db/schema.clj
+++ b/src/tiny_queue/db/schema.clj
@@ -39,13 +39,13 @@
     :db/valueType          :db.type/long
     :db/cardinality        :db.cardinality/one
     :db/noHistory          true
-    :db/doc                "Database-unique entity id for an object (stored in an external database: object-db-conn)."}
+    :db/doc                "Database-unique entity id for an object (stored in an external database)."}
 
    {:db/ident              :qmessage/object-uuid
     :db/valueType          :db.type/uuid
     :db/cardinality        :db.cardinality/one
     :db/noHistory          true
-    :db/doc                "UUID for an object (stored in an external database: object-db-conn)."}
+    :db/doc                "UUID for an object (stored in an external database)."}
 
    {:db/ident              :qmessage/processed-at
     :db/valueType          :db.type/instant

--- a/src/tiny_queue/db/transaction.clj
+++ b/src/tiny_queue/db/transaction.clj
@@ -43,3 +43,11 @@
      [:db/cas id :qmessage/processor-uuid processor-id processor-id]
      [:db/cas id :qmessage/result nil (u/result->string result)]
      [:db/add id :qmessage/status :qmessage-status/succeeded]]))
+
+(defn transaction-fail-transaction [job processor-id fail-time transaction]
+  (let [id (:db/id job)]
+    [[:db/cas id :qmessage/success nil false]
+     [:db/cas id :qmessage/processed-at nil (u/to-database-date fail-time)]
+     [:db/cas id :qmessage/processor-uuid processor-id processor-id]
+     [:db/cas id :qmessage/result nil (prn-str transaction)]
+     [:db/add id :qmessage/status :qmessage-status/transaction-failed]]))

--- a/src/tiny_queue/db/transaction.clj
+++ b/src/tiny_queue/db/transaction.clj
@@ -49,5 +49,5 @@
     [[:db/add id :qmessage/success false]
      [:db/add id :qmessage/processed-at (u/to-database-date fail-time)]
      [:db/add id :qmessage/processor-uuid processor-id]
-     [:db/add id :qmessage/result (prn-str transaction)]
+     [:db/add id :qmessage/result (u/result->string transaction)]
      [:db/add id :qmessage/status :qmessage-status/transaction-failed]]))

--- a/src/tiny_queue/db/transaction.clj
+++ b/src/tiny_queue/db/transaction.clj
@@ -46,8 +46,8 @@
 
 (defn transaction-fail-transaction [job processor-id fail-time transaction]
   (let [id (:db/id job)]
-    [[:db/cas id :qmessage/success nil false]
-     [:db/cas id :qmessage/processed-at nil (u/to-database-date fail-time)]
-     [:db/cas id :qmessage/processor-uuid processor-id processor-id]
-     [:db/cas id :qmessage/result nil (prn-str transaction)]
+    [[:db/add id :qmessage/success false]
+     [:db/add id :qmessage/processed-at (u/to-database-date fail-time)]
+     [:db/add id :qmessage/processor-uuid processor-id]
+     [:db/add id :qmessage/result (prn-str transaction)]
      [:db/add id :qmessage/status :qmessage-status/transaction-failed]]))

--- a/src/tiny_queue/spec.clj
+++ b/src/tiny_queue/spec.clj
@@ -58,8 +58,6 @@
 
 (s/def ::q any?)
 
-(s/def ::object-db-conn any?)
-
 (s/def ::tiny-queue-db-conn any?)
 
 (s/def ::db any?)
@@ -67,8 +65,7 @@
 (s/def ::transact any?)
 
 (s/def ::config
-  (s/keys :req-un [::object-db-conn
-                   ::tiny-queue-db-conn
+  (s/keys :req-un [::tiny-queue-db-conn
                    ::q
                    ::db
                    ::transact

--- a/test/tiny_queue/config_test.clj
+++ b/test/tiny_queue/config_test.clj
@@ -6,7 +6,6 @@
   (testing "Check valid config without optional fields."
     (let [validated-config (config/check-config
                             {:tiny-queue-db-conn "some-connection"
-                             :object-db-conn "some-connection"
                              :db (constantly nil)
                              :q (constantly nil)
                              :transact (constantly nil)
@@ -21,7 +20,6 @@
   (testing "Check valid config with optional fields."
     (let [validated-config (config/check-config
                             {:tiny-queue-db-conn "some-connection"
-                             :object-db-conn "some-connection"
                              :db (constantly nil)
                              :q (constantly nil)
                              :transact (constantly nil)
@@ -42,7 +40,6 @@
     (let [validated-config (try
                              (config/check-config
                               {:tiny-queue-db-conn "some-connection"
-                               :object-db-conn "some-connection"
                                :db (constantly nil)
                                :q (constantly nil)
                                :transact (constantly nil)


### PR DESCRIPTION
1. Remove `object-db-conn` from config.
2. Treat transactions to `object-db-conn` as side effects - they should be run inside a job processor.
4. Add `try-transact` function -- transactions to `tiny-queue-conn` should always succeed.
5. 1 side effect that is not idempotent per 1 job.