### PR TITLE
Make the queue more resilient:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.spinney/tiny-queue "1.0.19"
+(defproject io.spinney/tiny-queue "1.0.20"
   :description "A Clojure implementation of message queue that is based on datomic."
   :url "https://github.com/spinneyio/tiny-queue"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.spinney/tiny-queue "1.0.17"
+(defproject io.spinney/tiny-queue "1.0.18"
   :description "A Clojure implementation of message queue that is based on datomic."
   :url "https://github.com/spinneyio/tiny-queue"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.spinney/tiny-queue "1.0.18"
+(defproject io.spinney/tiny-queue "1.0.19"
   :description "A Clojure implementation of message queue that is based on datomic."
   :url "https://github.com/spinneyio/tiny-queue"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.spinney/tiny-queue "1.0.14"
+(defproject io.spinney/tiny-queue "1.0.15"
   :description "A Clojure implementation of message queue that is based on datomic."
   :url "https://github.com/spinneyio/tiny-queue"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.spinney/tiny-queue "1.0.16"
+(defproject io.spinney/tiny-queue "1.0.17"
   :description "A Clojure implementation of message queue that is based on datomic."
   :url "https://github.com/spinneyio/tiny-queue"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.spinney/tiny-queue "1.0.15"
+(defproject io.spinney/tiny-queue "1.0.16"
   :description "A Clojure implementation of message queue that is based on datomic."
   :url "https://github.com/spinneyio/tiny-queue"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/tiny_queue/core.clj
+++ b/src/tiny_queue/core.clj
@@ -122,7 +122,7 @@
                       :db/ident)
         processor (processor-id tiny-queue-processors)]
     (try      
-      (assert processor "No processor found for command: " processor-id)
+      (assert processor (str "No processor found for command: " processor-id))
       (let [tiny-queue-db-transaction (u/with-timeout 60000 (processor
                                                              tiny-queue-db-snapshot
                                                              job

--- a/src/tiny_queue/core.clj
+++ b/src/tiny_queue/core.clj
@@ -117,16 +117,16 @@
                 job-processor-failed-interval-in-s
                 tiny-queue-processors
                 transact]} config
-        processor (-> job
+        processor-id (-> job
                       :qmessage/qcommand
-                      :db/ident
-                      tiny-queue-processors)]
-    (assert processor "No processor found!")
-    (try
-      (let [tiny-queue-db-transaction (processor
-                                       tiny-queue-db-snapshot
-                                       job
-                                       processor-uuid)
+                      :db/ident)
+        processor (processor-id tiny-queue-processors)]
+    (try      
+      (assert processor "No processor found for command: " processor-id)
+      (let [tiny-queue-db-transaction (u/with-timeout 60000 (processor
+                                                             tiny-queue-db-snapshot
+                                                             job
+                                                             processor-uuid))
             success-transaction (db-transaction/success-transaction
                                  job
                                  processor-uuid

--- a/src/tiny_queue/core.clj
+++ b/src/tiny_queue/core.clj
@@ -166,7 +166,7 @@
   "A version of grab-process-job that throws if a job cannot be grabbed or ends with an exception."
   [config tiny-queue-db-snapshot job]
   (assert (grab-job config job) (str "Cannot grab the job: " job))
-  (process-job config tiny-queue-db-snapshot job true))
+  (process-job (dissoc config :log) tiny-queue-db-snapshot job true))
 
 (defn wrap-background-job
   [config ^Long remaining-time]

--- a/src/tiny_queue/core.clj
+++ b/src/tiny_queue/core.clj
@@ -166,7 +166,7 @@
   "A version of grab-process-job that throws if a job cannot be grabbed or ends with an exception."
   [config tiny-queue-db-snapshot job]
   (assert (grab-job config job) (str "Cannot grab the job: " job))
-  (process-job (dissoc config :log) tiny-queue-db-snapshot job true))
+  (process-job config tiny-queue-db-snapshot job true))
 
 (defn wrap-background-job
   [config ^Long remaining-time]

--- a/src/tiny_queue/utils.clj
+++ b/src/tiny_queue/utils.clj
@@ -36,4 +36,5 @@
         (catch java.util.concurrent.TimeoutException x# 
           (do
             (future-cancel future#)
+            (throw x#)
             nil)))))

--- a/src/tiny_queue/utils.clj
+++ b/src/tiny_queue/utils.clj
@@ -28,3 +28,12 @@
 
 (defn exception-description [e]
   (str (class e) " received in: " (stacktrace e) ": " (.getMessage e)))
+
+(defmacro with-timeout [millis & body]
+    `(let [future# (future ~@body)]
+      (try
+        (.get future# ~millis java.util.concurrent.TimeUnit/MILLISECONDS)
+        (catch java.util.concurrent.TimeoutException x# 
+          (do
+            (future-cancel future#)
+            nil)))))


### PR DESCRIPTION
1. Move the assert into try/catch so that if we cannot find processor we do not kill the queue
2. Add a 60 sec timeout to every job.